### PR TITLE
Nested resolvers

### DIFF
--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -15,6 +15,7 @@ import logging
 from os import environ, path, walk
 from pkg_resources import iter_entry_points
 import yaml
+import re
 
 from jinja2 import Environment
 from jinja2 import StrictUndefined
@@ -391,6 +392,10 @@ class ConfigReader(object):
                 environment_variable=environ
             )
 
+            findall = re.findall(r"(')(!.*)(\1)", rendered_template)
+            for res in findall:
+                rendered_template = rendered_template.replace(f"{res[0]}{res[1]}{res[2]}", res[1])
+            
             config = yaml.safe_load(rendered_template)
 
             return config

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -395,7 +395,7 @@ class ConfigReader(object):
             findall = re.findall(r"(')(!.*)(\1)", rendered_template)
             for res in findall:
                 rendered_template = rendered_template.replace(f"{res[0]}{res[1]}{res[2]}", res[1])
-            
+
             config = yaml.safe_load(rendered_template)
 
             return config


### PR DESCRIPTION
With the below it seems jinja does some weird things with what it's doing with strings and how pyyaml inteprets the custom tags after that.

See the difference between `<sceptre.resolvers.stack_output.StackOutputExternal object at 0x10cd57d30>` and `'!stack_output_external transit-gateway-attachment::RouteTable1'` in the produced config

Possibly there are better ways to do this


Example config:
```yaml
---
source:
  path: transit-gateway-routing
  targetRevision: master

NameTagValue: transit-gateway-routing

TransitGatewayId: '!stack_output_external transit-gateway-transit-gateway::TransitGatewayId'
RouteTableName: transit-gateway-test

AssociationIds:
  - '!stack_output_external transit-gateway-attachment::TransitGatewayAttachment'
  - tgw-attach-0c3b005d685570528

PropagationIds:
  - tgw-attach-0c3b005d685570528

```
Before:
```
Config: {'parameters': {'TransitGatewayId': <sceptre.resolvers.stack_output.StackOutputExternal object at 0x10c309438>, 'RouteTableName': 'transit-gateway-test'}, 'sceptre_user_data': {'association_ids': ['tgw-attach-0c3b005d685570528', '!stack_output_external transit-gateway-attachment::RouteTable1'], 'propagation_ids': ['tgw-attach-0c3b005d685570528']}
## PR Checklist
```
After:
```
Config: {'parameters': {'TransitGatewayId': <sceptre.resolvers.stack_output.StackOutputExternal object at 0x10cd57358>, 'RouteTableName': 'transit-gateway-test'}, 'sceptre_user_data': {'association_ids': ['tgw-attach-0c3b005d685570528', <sceptre.resolvers.stack_output.StackOutputExternal object at 0x10cd57d30>], 'propagation_ids': ['tgw-attach-0c3b005d685570528']}
```

- [ ] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [ ] All unit tests (`make test`) are passing.
- [ ] Used the same coding conventions as the rest of the project.
- [ ] The new code passes flake8 (`make lint`) checks.
- [ ] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
